### PR TITLE
Improvements for S3 & E2

### DIFF
--- a/1__setup/3__emulated_ue/1__install.sh
+++ b/1__setup/3__emulated_ue/1__install.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export SIMURAI_SKIP_ADB_CHECK="1";
+
 readonly ROOT=$(realpath $(dirname "$0")/../..);
 readonly UTIL=${ROOT}/util;
 source ${UTIL}/preamble.sh;

--- a/1__setup/3__emulated_ue/3__uninstall.sh
+++ b/1__setup/3__emulated_ue/3__uninstall.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export SIMURAI_SKIP_ADB_CHECK="1";
+
 readonly ROOT="$(realpath $(dirname "$0")/../..)";
 readonly UTIL=""${ROOT}"/util";
 source ${UTIL}/preamble.sh;

--- a/1__setup/3__emulated_ue/docker/dockerfile
+++ b/1__setup/3__emulated_ue/docker/dockerfile
@@ -25,5 +25,8 @@ RUN set -eux; \
     ldconfig; \
     pip3 install pyscard;
 
+# Manually install pinned unicorn version for compability with avatar2 (dependency of FirmWire)
+RUN pip3 install unicorn==2.0.1.post1
+
 COPY --chmod=700 ./entrypoint.sh /opt/setup
 ENTRYPOINT ["/opt/setup/entrypoint.sh"]

--- a/2__experiment/2__fuzzing/1__install.sh
+++ b/2__experiment/2__fuzzing/1__install.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export SIMURAI_SKIP_ADB_CHECK="1";
+
 readonly ROOT="$(realpath $(dirname "$0")/../..)";
 readonly UTIL="${ROOT}/util";
 source ${UTIL}/preamble.sh;

--- a/2__experiment/2__fuzzing/2__run.sh
+++ b/2__experiment/2__fuzzing/2__run.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export SIMURAI_SKIP_ADB_CHECK="1";
+
 readonly ROOT=$(realpath $(dirname "$0")/../..);
 readonly UTIL=${ROOT}/util;
 source ${UTIL}/preamble.sh;

--- a/2__experiment/2__fuzzing/3__replay.sh
+++ b/2__experiment/2__fuzzing/3__replay.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export SIMURAI_SKIP_ADB_CHECK="1";
+
 readonly ROOT=$(realpath $(dirname "$0")/../..);
 readonly UTIL=${ROOT}/util;
 source ${UTIL}/preamble.sh;

--- a/2__experiment/2__fuzzing/4__uninstall.sh
+++ b/2__experiment/2__fuzzing/4__uninstall.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export SIMURAI_SKIP_ADB_CHECK="1";
+
 readonly ROOT=$(realpath $(dirname "$0")/../..);
 readonly UTIL=${ROOT}/util;
 source ${UTIL}/preamble.sh;

--- a/util/check_adb.sh
+++ b/util/check_adb.sh
@@ -1,19 +1,26 @@
 #!/bin/bash
-adb start-server;
 
-# Make sure that server is up and devices had a chance to register 
-sleep 3;
+if [[ "${SIMURAI_SKIP_ADB_CHECK:-0}" -eq "1" ]]; then
+    printf "%sSkipping ADB check.%s\n" "${CCHK}" "${CDEF}";
+else
 
-check "If UE1 is connected and visible to ADB."
-adb -s "${UE1_SERIAL}" get-state;
-if ! checkResult "${?}" "UE1 is present." "Please plug in UE1. It is possible that you did not configure the serial number of UE1 correctly, take a look at \"util/adb_serial.sh\"."; then
-    exit 1;
+    adb start-server;
+
+    # Make sure that server is up and devices had a chance to register
+    sleep 3;
+
+    check "If UE1 is connected and visible to ADB."
+    adb -s "${UE1_SERIAL}" get-state;
+    if ! checkResult "${?}" "UE1 is present." "Please plug in UE1. It is possible that you did not configure the serial number of UE1 correctly, take a look at \"util/adb_serial.sh\"."; then
+        exit 1;
+    fi
+
+    check "If UE2 is connected and visible to ADB."
+    adb -s "${UE2_SERIAL}" get-state;
+    if ! checkResult "${?}" "UE2 is present." "Please plug in UE2. It is possible that you did not configure the serial number of UE2 correctly, take a look at \"util/adb_serial.sh\"."; then
+        exit 1;
+    fi
+
+    adb kill-server;
+
 fi
-
-check "If UE2 is connected and visible to ADB."
-adb -s "${UE2_SERIAL}" get-state;
-if ! checkResult "${?}" "UE2 is present." "Please plug in UE2. It is possible that you did not configure the serial number of UE2 correctly, take a look at \"util/adb_serial.sh\"."; then
-    exit 1;
-fi
-
-adb kill-server;


### PR DESCRIPTION
This PR provides 2 improvements:

1) Allow the fully virtual setups to run without attached phones/changed ADB serial numbers
2) Fix a compatibility issue: Unicorn, a third-party dependency of avatar2 (used by FirmWire) got updated, which breaks avatar2. This fix pins the unicorn version to the one used during the original AE.